### PR TITLE
Fix environment for DPS deploy

### DIFF
--- a/build-env.sh
+++ b/build-env.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 # Get current location of build script
 basedir=$( cd "$(dirname "$0")" ; pwd -P )
 
-conda env update -f ${basedir}/environment_complete.yml
+conda env update -f ${basedir}/environment.yml

--- a/environment.yml
+++ b/environment.yml
@@ -532,7 +532,6 @@ dependencies:
       - rio-tiler==7.2.2
       - rioxarray==0.19.0
       - setuptools==69.5.1
-      - stac-ipyleaflet==0.3.6
 variables:
   TITILER_STAC_ENDPOINT: https://titiler-pgstac.maap-project.org/
   TITILER_ENDPOINT: https://titiler.maap-project.org/


### PR DESCRIPTION
Working deployment with arguments:
```
result = maap.submitJob(
       [...]
        schema_path="s3://path/to/public/schema",
        bucket="maap-ops-workspace",
        prefix="shared/ameliah/gedi-test/tiles_v6",
        tile_id="N45_W105",
        test="test",
    )
```